### PR TITLE
Added setting for max shadow texture size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,25 @@ pub struct InfiniteGridPlugin;
 
 impl Plugin for InfiniteGridPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<InfiniteGridSettings>();
         render::render_app_builder(app);
         app.add_system_to_stage(CoreStage::PostUpdate, track_frustum_intersect_system)
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 track_caster_visibility.after(VisibilitySystems::CheckVisibility),
             );
+    }
+}
+
+pub struct InfiniteGridSettings {
+    pub max_texture_size: u32,
+}
+
+impl Default for InfiniteGridSettings {
+    fn default() -> Self {
+        Self {
+            max_texture_size: 16384,
+        }
     }
 }
 

--- a/src/render/shadow.rs
+++ b/src/render/shadow.rs
@@ -39,7 +39,7 @@ use bevy::{
     window::WindowId,
 };
 
-use crate::GridFrustumIntersect;
+use crate::{GridFrustumIntersect, InfiniteGridSettings};
 
 use super::{ExtractedInfiniteGrid, InfiniteGridPipeline};
 
@@ -236,6 +236,7 @@ fn prepare_grid_shadow_views(
     render_device: Res<RenderDevice>,
     mut texture_cache: ResMut<TextureCache>,
     windows: Res<ExtractedWindows>,
+    settings: Res<InfiniteGridSettings>,
 ) {
     let primary_window = windows.get(&WindowId::primary()).unwrap();
     let width = primary_window.physical_width;
@@ -247,7 +248,7 @@ fn prepare_grid_shadow_views(
         [height, width]
     };
     let ratio = min as f32 / max as f32;
-    let tmax = 16384u32;
+    let tmax = settings.max_texture_size;
     let tmin = (tmax as f32 * ratio) as u32;
     let [width, height] = if comp { [tmin, tmax] } else { [tmax, tmin] };
     for (entity, grid, frustum_intersect) in grids.iter() {


### PR DESCRIPTION
I encountered a bug when I ran my software on a weaker device using a large screen that gave the error that the Dimension X which was 16384 was over the limit. After identifying the issue in wgpu I found that reducing tmax for the shadow texture fixed the problem. 

This PR adds a settings resource that lets you set the maximum size of the texture. It might not be a permanent solution but it is enough of a workaround to get it running again. If you have the knowledge of how this could be done better feel free to ignore this PR and do that instead.