### PR TITLE
Added setting for max shadow texture size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 mod render;
 
+pub use render::RenderSettings;
+
 use bevy::math::{Vec3Swizzles, Vec4Swizzles};
 use bevy::prelude::*;
 use bevy::render::camera::Camera3d;
@@ -11,6 +13,7 @@ pub struct InfiniteGridPlugin;
 
 impl Plugin for InfiniteGridPlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<InfiniteGridSettings>();
         render::render_app_builder(app);
         app.add_system_to_stage(CoreStage::PostUpdate, track_frustum_intersect_system)
             .add_system_to_stage(
@@ -18,6 +21,11 @@ impl Plugin for InfiniteGridPlugin {
                 track_caster_visibility.after(VisibilitySystems::CheckVisibility),
             );
     }
+}
+
+#[derive(Default)]
+pub struct InfiniteGridSettings {
+    pub render_settings: RenderSettings,
 }
 
 #[derive(Component, Copy, Clone)]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,5 +1,7 @@
 mod shadow;
 
+pub use shadow::RenderSettings;
+
 use std::borrow::Cow;
 
 use bevy::{

--- a/src/render/shadow.rs
+++ b/src/render/shadow.rs
@@ -509,7 +509,8 @@ pub fn register_shadow(app: &mut App) {
         .init_resource::<GridShadowMeta>()
         .init_resource::<GridShadowPipeline>()
         .init_resource::<DrawFunctions<GridShadow>>()
-        .init_resource::<SpecializedMeshPipelines<GridShadowPipeline>>().insert_resource(render_settings)
+        .init_resource::<SpecializedMeshPipelines<GridShadowPipeline>>()
+        .insert_resource(render_settings)
         .add_render_command::<GridShadow, DrawGridShadowMesh>()
         .add_system_to_stage(
             RenderStage::Prepare,


### PR DESCRIPTION
I encountered a bug when I ran my software on a weaker device using a large screen that gave the error that the Dimension X which was 16384 was over the limit. After identifying the issue in wgpu I found that reducing tmax for the shadow texture fixed the problem.

This PR adds a settings resource that lets you set the maximum size of the texture. It might not be a permanent solution but it is enough of a workaround to get it running again. If you have the knowledge of how this could be done better feel free to ignore this PR and do that instead.