### PR TITLE
Don't write depth when drawing the grid.

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -559,7 +559,7 @@ impl SpecializedRenderPipeline for InfiniteGridPipeline {
             },
             depth_stencil: Some(DepthStencilState {
                 format: TextureFormat::Depth32Float,
-                depth_write_enabled: true,
+                depth_write_enabled: false,
                 depth_compare: CompareFunction::Greater,
                 stencil: StencilState {
                     front: StencilFaceState::IGNORE,


### PR DESCRIPTION
The grid is a transparent object and so standard practice would be to disable depth writes. This is in line what Bevy does for other objects in the transparent pass.

This allows transparent objects behind the grid to show up, e.g. Bevy Hanabi particles.

An alternative would be to use `discard` to discard fully transparent pixels, though this wouldn't fix the rendering of pixels that are neither fully opaque nor fully transparent.

Closes #29.