### PR TITLE
Draft: Update to Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["bevy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.11.0", default-features = false, features = [
+bevy = { version = "0.12.0", default-features = false, features = [
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_pbr",
@@ -23,7 +23,7 @@ bevy = { version = "0.11.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.11.0", default-features = false, features = [
+bevy = { version = "0.12.0", default-features = false, features = [
     "bevy_winit",
     "x11",
     "tonemapping_luts",

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -148,7 +148,7 @@ mod camera_controller {
             // Handle mouse input
             let mut mouse_delta = Vec2::ZERO;
             if mouse_button_input.pressed(MouseButton::Left) {
-                for mouse_event in mouse_events.iter() {
+                for mouse_event in mouse_events.read() {
                     mouse_delta += mouse_event.delta;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,8 @@ pub struct InfiniteGridBundle {
     pub grid: InfiniteGrid,
     pub frustum_intersect: GridFrustumIntersect,
     pub visibility: Visibility,
-    pub computed_visibility: ComputedVisibility,
+    pub inherited_visibility: InheritedVisibility,
+    pub view_visibility: ViewVisibility,
     pub shadow_casters: VisibleEntities,
     pub no_frustum_culling: NoFrustumCulling,
 }
@@ -231,7 +232,7 @@ fn track_caster_visibility(
         (
             Entity,
             &Visibility,
-            &mut ComputedVisibility,
+            &mut ViewVisibility,
             Option<(&GlobalTransform, &Aabb)>,
         ),
         (With<Handle<Mesh>>, Without<NotShadowCaster>),
@@ -239,13 +240,13 @@ fn track_caster_visibility(
 ) {
     for (mut visibles, _grid_transform, _grid) in grids.iter_mut() {
         visibles.entities.clear();
-        for (entity, visibility, mut computed, _intersect_testable) in meshes.iter_mut() {
+        for (entity, visibility, mut view, _intersect_testable) in meshes.iter_mut() {
             if let Visibility::Hidden = visibility {
                 continue;
             }
 
             // TODO: add a check here for if the projection of the aabb onto the plane has any overlap with the grid frustum intersect
-            computed.set_visible_in_view();
+            view.set();
             visibles.entities.push(entity);
         }
     }

--- a/src/render/shadow_render.wgsl
+++ b/src/render/shadow_render.wgsl
@@ -1,6 +1,6 @@
-#import bevy_pbr::mesh_functions mesh_position_local_to_clip
-#import bevy_pbr::mesh_types Mesh
-#import bevy_render::view View
+#import bevy_pbr::mesh_functions::mesh_position_local_to_clip
+#import bevy_pbr::mesh_types::Mesh
+#import bevy_render::view::View
 
 @group(0) @binding(0)
 var<uniform> view: View;
@@ -13,9 +13,6 @@ var<uniform> mesh: Mesh;
 var<uniform> joint_matrices: SkinnedMesh;
 #import bevy_pbr::skinning
 #endif
-
-// NOTE: Bindings must come before functions that use them!
-#import bevy_pbr::mesh_functions mesh_position_local_to_clip
 
 struct Vertex {
     @location(0) position: vec3<f32>,


### PR DESCRIPTION
Updates the crate to Bevy 0.12.

I am currently still getting a crash when i run the example:

```
thread 'main' panicked at ...\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bevy_render-0.12.0\src\render_phase\draw.rs:274:54:
called `Result::unwrap()` on an `Err` value: QueryDoesNotMatch(2v0)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_render::renderer::render_system`!
error: process didn't exit successfully: `target\debug\examples\simple.exe` (exit code: 101)
```

the actual bevy code which breaks this is here:

```diff
impl<P: PhaseItem, C: RenderCommand<P> + Send + Sync + 'static> Draw<P> for RenderCommandState<P, C>
where
    C::Param: ReadOnlySystemParam,
{
    /// Prepares the render command to be used. This is called once and only once before the phase
    /// begins. There may be zero or more [`draw`](RenderCommandState::draw) calls following a call to this function.
    fn prepare(&mut self, world: &'_ World) {
        self.state.update_archetypes(world);
        self.view.update_archetypes(world);
        self.entity.update_archetypes(world);
    }

    /// Fetches the ECS parameters for the wrapped [`RenderCommand`] and then renders it.
    fn draw<'w>(
        &mut self,
        world: &'w World,
        pass: &mut TrackedRenderPass<'w>,
        view: Entity,
        item: &P,
    ) {
        let param = self.state.get_manual(world);
+       let view = self.view.get_manual(world, view).unwrap();
        let entity = self.entity.get_manual(world, item.entity()).unwrap();
        // TODO: handle/log `RenderCommand` failure
        C::render(item, view, entity, param, pass);
    }
}
```

If anyone has an idea, you are very welcome. Otherwise, i will take a look at it tomorrow, i don't have any more time today.