### PR TITLE
Update to Bevy 0.12.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["bevy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.11.0", default-features = false, features = [
+bevy = { version = "0.12.0", default-features = false, features = [
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_pbr",
@@ -23,7 +23,7 @@ bevy = { version = "0.11.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.11.0", default-features = false, features = [
+bevy = { version = "0.12.0", default-features = false, features = [
     "bevy_winit",
     "x11",
     "tonemapping_luts",

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -148,7 +148,7 @@ mod camera_controller {
             // Handle mouse input
             let mut mouse_delta = Vec2::ZERO;
             if mouse_button_input.pressed(MouseButton::Left) {
-                for mouse_event in mouse_events.iter() {
+                for mouse_event in mouse_events.read() {
                     mouse_delta += mouse_event.delta;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,8 @@ pub struct InfiniteGridBundle {
     pub grid: InfiniteGrid,
     pub frustum_intersect: GridFrustumIntersect,
     pub visibility: Visibility,
-    pub computed_visibility: ComputedVisibility,
+    pub view_visibility: ViewVisibility,
+    pub inherited_visibility: InheritedVisibility,
     pub shadow_casters: VisibleEntities,
     pub no_frustum_culling: NoFrustumCulling,
 }
@@ -231,7 +232,7 @@ fn track_caster_visibility(
         (
             Entity,
             &Visibility,
-            &mut ComputedVisibility,
+            &mut InheritedVisibility,
             Option<(&GlobalTransform, &Aabb)>,
         ),
         (With<Handle<Mesh>>, Without<NotShadowCaster>),
@@ -239,13 +240,13 @@ fn track_caster_visibility(
 ) {
     for (mut visibles, _grid_transform, _grid) in grids.iter_mut() {
         visibles.entities.clear();
-        for (entity, visibility, mut computed, _intersect_testable) in meshes.iter_mut() {
+        for (entity, visibility, mut inherited_visibility, _intersect_testable) in meshes.iter_mut() {
             if let Visibility::Hidden = visibility {
                 continue;
             }
 
             // TODO: add a check here for if the projection of the aabb onto the plane has any overlap with the grid frustum intersect
-            computed.set_visible_in_view();
+            *inherited_visibility = InheritedVisibility::VISIBLE;
             visibles.entities.push(entity);
         }
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -15,7 +15,6 @@ use bevy::{
     },
     pbr::MeshPipelineKey,
     prelude::*,
-    reflect::TypeUuid,
     render::{
         mesh::PrimitiveTopology,
         render_phase::{
@@ -23,14 +22,13 @@ use bevy::{
             RenderPhase, SetItemPipeline,
         },
         render_resource::{
-            BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout,
-            BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, BlendState,
-            BufferBindingType, BufferSize, ColorTargetState, ColorWrites, CompareFunction,
-            DepthBiasState, DepthStencilState, DynamicUniformBuffer, FragmentState,
-            MultisampleState, PipelineCache, PolygonMode, PrimitiveState, RenderPipelineDescriptor,
-            SamplerBindingType, ShaderStages, ShaderType, SpecializedRenderPipeline,
-            SpecializedRenderPipelines, StencilFaceState, StencilState, TextureFormat,
-            TextureSampleType, TextureViewDimension, VertexState,
+            BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutDescriptor,
+            BindGroupLayoutEntry, BindingType, BlendState, BufferBindingType, BufferSize,
+            ColorTargetState, ColorWrites, CompareFunction, DepthBiasState, DepthStencilState,
+            DynamicUniformBuffer, FragmentState, MultisampleState, PipelineCache, PolygonMode,
+            PrimitiveState, RenderPipelineDescriptor, SamplerBindingType, ShaderStages, ShaderType,
+            SpecializedRenderPipeline, SpecializedRenderPipelines, StencilFaceState, StencilState,
+            TextureFormat, TextureSampleType, TextureViewDimension, VertexState,
         },
         renderer::{RenderDevice, RenderQueue},
         texture::BevyDefault,
@@ -45,8 +43,7 @@ use shadow::{GridShadow, SetGridShadowBindGroup};
 
 static PLANE_RENDER: &str = include_str!("plane_render.wgsl");
 
-const SHADER_HANDLE: HandleUntyped =
-    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 15204473893972682982);
+const SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(15204473893972682982);
 
 #[derive(Component)]
 struct ExtractedInfiniteGrid {
@@ -212,7 +209,7 @@ impl<P: PhaseItem> RenderCommand<P> for FinishDrawInfiniteGrid {
     }
 }
 
-fn prepare_grid_view_bind_groups(
+fn prepare_grid_view_uniforms(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
@@ -240,7 +237,7 @@ fn prepare_grid_view_bind_groups(
         .write_buffer(&render_device, &render_queue)
 }
 
-fn queue_grid_view_bind_groups(
+fn prepare_grid_view_bind_groups(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     uniforms: Res<GridViewUniforms>,
@@ -249,14 +246,11 @@ fn queue_grid_view_bind_groups(
 ) {
     if let Some(binding) = uniforms.uniforms.binding() {
         for entity in views.iter() {
-            let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
-                label: Some("grid-view-bind-group"),
-                layout: &pipeline.view_layout,
-                entries: &[BindGroupEntry {
-                    binding: 0,
-                    resource: binding.clone(),
-                }],
-            });
+            let bind_group = render_device.create_bind_group(
+                "grid-view-bind-group",
+                &pipeline.view_layout,
+                &BindGroupEntries::single(binding.clone()),
+            );
             commands
                 .entity(entity)
                 .insert(GridViewBindGroup { value: bind_group });
@@ -416,16 +410,35 @@ fn prepare_grid_shadows(
         .write_buffer(&render_device, &render_queue);
 }
 
-#[allow(clippy::too_many_arguments)]
-fn queue_infinite_grids(
-    pipeline_cache: Res<PipelineCache>,
-    transparent_draw_functions: Res<DrawFunctions<Transparent3d>>,
+fn prepare_bind_groups_for_infinite_grids(
     mut commands: Commands,
     position_uniforms: Res<InfiniteGridUniforms>,
     settings_uniforms: Res<GridDisplaySettingsUniforms>,
     pipeline: Res<InfiniteGridPipeline>,
-    mut pipelines: ResMut<SpecializedRenderPipelines<InfiniteGridPipeline>>,
     render_device: Res<RenderDevice>,
+) {
+    let bind_group = if let Some((position_binding, settings_binding)) = position_uniforms
+        .uniforms
+        .binding()
+        .zip(settings_uniforms.uniforms.binding())
+    {
+        render_device.create_bind_group(
+            "infinite-grid-bind-group",
+            &pipeline.infinite_grid_layout,
+            &BindGroupEntries::sequential((position_binding.clone(), settings_binding.clone())),
+        )
+    } else {
+        return;
+    };
+    commands.insert_resource(InfiniteGridBindGroup { value: bind_group });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn queue_infinite_grids(
+    pipeline_cache: Res<PipelineCache>,
+    transparent_draw_functions: Res<DrawFunctions<Transparent3d>>,
+    pipeline: Res<InfiniteGridPipeline>,
+    mut pipelines: ResMut<SpecializedRenderPipelines<InfiniteGridPipeline>>,
     infinite_grids: Query<&ExtractedInfiniteGrid>,
     intersects: Query<&GridFrustumIntersect>,
     mut views: Query<(
@@ -435,30 +448,6 @@ fn queue_infinite_grids(
     )>,
     msaa: Res<Msaa>,
 ) {
-    let bind_group = if let Some((position_binding, settings_binding)) = position_uniforms
-        .uniforms
-        .binding()
-        .zip(settings_uniforms.uniforms.binding())
-    {
-        render_device.create_bind_group(&BindGroupDescriptor {
-            label: Some("infinite-grid-bind-group"),
-            layout: &pipeline.infinite_grid_layout,
-            entries: &[
-                BindGroupEntry {
-                    binding: 0,
-                    resource: position_binding.clone(),
-                },
-                BindGroupEntry {
-                    binding: 1,
-                    resource: settings_binding.clone(),
-                },
-            ],
-        })
-    } else {
-        return;
-    };
-    commands.insert_resource(InfiniteGridBindGroup { value: bind_group });
-
     let draw_function_id = transparent_draw_functions
         .read()
         .get_id::<DrawInfiniteGrid>()
@@ -498,6 +487,8 @@ fn queue_infinite_grids(
                     entity,
                     draw_function: draw_function_id,
                     distance: f32::NEG_INFINITY,
+                    batch_range: 0..1,
+                    dynamic_offset: None,
                 });
             }
         }
@@ -639,7 +630,7 @@ impl SpecializedRenderPipeline for InfiniteGridPipeline {
                 .collect(),
             push_constant_ranges: Vec::new(),
             vertex: VertexState {
-                shader: SHADER_HANDLE.typed(),
+                shader: SHADER_HANDLE,
                 shader_defs: vec![],
                 entry_point: Cow::Borrowed("vertex"),
                 buffers: vec![],
@@ -675,7 +666,7 @@ impl SpecializedRenderPipeline for InfiniteGridPipeline {
                 alpha_to_coverage_enabled: false,
             },
             fragment: Some(FragmentState {
-                shader: SHADER_HANDLE.typed(),
+                shader: SHADER_HANDLE,
                 shader_defs: key
                     .has_shadows
                     .then(|| "SHADOWS".into())
@@ -695,7 +686,7 @@ impl SpecializedRenderPipeline for InfiniteGridPipeline {
 pub fn render_app_builder(app: &mut App) {
     app.world
         .resource_mut::<Assets<Shader>>()
-        .set_untracked(SHADER_HANDLE, Shader::from_wgsl(PLANE_RENDER, file!()));
+        .get_or_insert_with(SHADER_HANDLE, || Shader::from_wgsl(PLANE_RENDER, file!()));
 
     let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
         return;
@@ -718,14 +709,19 @@ pub fn render_app_builder(app: &mut App) {
             (
                 prepare_infinite_grids,
                 prepare_grid_shadows,
-                prepare_grid_view_bind_groups,
+                prepare_grid_view_uniforms,
             )
                 .in_set(RenderSet::Prepare),
         )
         .add_systems(
             Render,
-            (queue_infinite_grids, queue_grid_view_bind_groups).in_set(RenderSet::Queue),
-        );
+            (
+                prepare_bind_groups_for_infinite_grids,
+                prepare_grid_view_bind_groups,
+            )
+                .in_set(RenderSet::PrepareBindGroups),
+        )
+        .add_systems(Render, queue_infinite_grids.in_set(RenderSet::Queue));
 
     shadow::register_shadow(app);
 }

--- a/src/render/shadow_render.wgsl
+++ b/src/render/shadow_render.wgsl
@@ -1,6 +1,6 @@
-#import bevy_pbr::mesh_functions mesh_position_local_to_clip
-#import bevy_pbr::mesh_types Mesh
-#import bevy_render::view View
+#import bevy_pbr::mesh_functions::{mesh_position_local_to_clip, get_model_matrix}
+#import bevy_pbr::mesh_types::Mesh
+#import bevy_render::view::View
 
 @group(0) @binding(0)
 var<uniform> view: View;
@@ -14,8 +14,7 @@ var<uniform> joint_matrices: SkinnedMesh;
 #import bevy_pbr::skinning
 #endif
 
-// NOTE: Bindings must come before functions that use them!
-#import bevy_pbr::mesh_functions mesh_position_local_to_clip
+#import bevy_pbr::pbr_bindings
 
 struct Vertex {
     @location(0) position: vec3<f32>,
@@ -23,6 +22,7 @@ struct Vertex {
     @location(4) joint_indices: vec4<u32>,
     @location(5) joint_weights: vec4<f32>,
 #endif
+    @builtin(instance_index) instance_index: u32,
 };
 
 struct VertexOutput {
@@ -34,7 +34,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 #ifdef SKINNED
     let model = bevy_pbr::skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
 #else
-    let model = mesh.model;
+    let model = get_model_matrix(vertex.instance_index);
 #endif
 
     var out: VertexOutput;


### PR DESCRIPTION
Everything seems to work in both the simple example and in my own app.

The one thing I wasn't sure about was whether to rename the `queue_` methods to `prepare_` now that they've been moved to the `PrepareBindGroups` render set. They had to be moved there because in Bevy 0.12 `Queue` executes before `Prepare`, whereas this crate expected them to execute in the other order.