### PR TITLE
Fix visibility setting to ViewVisibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_infinite_grid"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
     "Nile <therawmeatball@gmail.com>",
     "Foresight Mining Software Corporation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_infinite_grid"
-version = "0.10.1"
+version = "0.10.0"
 authors = [
     "Nile <therawmeatball@gmail.com>",
     "Foresight Mining Software Corporation",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,8 +240,7 @@ fn track_caster_visibility(
 ) {
     for (mut visibles, _grid_transform, _grid) in grids.iter_mut() {
         visibles.entities.clear();
-        for (entity, visibility, mut view_visibility, _intersect_testable) in meshes.iter_mut()
-        {
+        for (entity, visibility, mut view_visibility, _intersect_testable) in meshes.iter_mut() {
             if let Visibility::Hidden = visibility {
                 continue;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ fn track_caster_visibility(
         (
             Entity,
             &Visibility,
-            &mut InheritedVisibility,
+            &mut ViewVisibility,
             Option<(&GlobalTransform, &Aabb)>,
         ),
         (With<Handle<Mesh>>, Without<NotShadowCaster>),
@@ -240,14 +240,14 @@ fn track_caster_visibility(
 ) {
     for (mut visibles, _grid_transform, _grid) in grids.iter_mut() {
         visibles.entities.clear();
-        for (entity, visibility, mut inherited_visibility, _intersect_testable) in meshes.iter_mut()
+        for (entity, visibility, mut view_visibility, _intersect_testable) in meshes.iter_mut()
         {
             if let Visibility::Hidden = visibility {
                 continue;
             }
 
             // TODO: add a check here for if the projection of the aabb onto the plane has any overlap with the grid frustum intersect
-            *inherited_visibility = InheritedVisibility::VISIBLE;
+            view_visibility.set();
             visibles.entities.push(entity);
         }
     }


### PR DESCRIPTION
Hello!

In the migration to 0.12 in #43, there was a mistake [here](https://github.com/ForesightMiningSoftwareCorporation/bevy_infinite_grid/pull/43/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L248-R249) where a `ComputedVisibility.set_visible_in_view()` was migrated to a setting to `InheritedVisibility`.
This resulted in the plugin breaking all hierarchical visibility propagations as soon as a grid is spawned, making everything always visible at all times.
In this PR I changed it to what it should have been migrated to, which is a setting to `ViewVisibility`.

CC @pcwalton  just for a sanity check