### PR TITLE
update to bevy 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 .idea/
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["bevy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.12.0", default-features = false, features = [
+bevy = { version = "0.13.0", default-features = false, features = [
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_pbr",
@@ -23,7 +23,7 @@ bevy = { version = "0.12.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.12.0", default-features = false, features = [
+bevy = { version = "0.13.0", default-features = false, features = [
     "bevy_winit",
     "x11",
     "tonemapping_luts",

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -44,7 +44,9 @@ fn setup_system(
     // cube
     commands.spawn(PbrBundle {
         material: mat.clone(),
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(Cuboid {
+            half_size: Vec3::splat(0.5),
+        }),
         transform: Transform {
             translation: Vec3::new(3., 4., 0.),
             rotation: Quat::from_rotation_arc(Vec3::Y, Vec3::ONE.normalize()),
@@ -55,7 +57,9 @@ fn setup_system(
 
     commands.spawn(PbrBundle {
         material: mat.clone(),
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 2.0 })),
+        mesh: meshes.add(Cuboid {
+            half_size: Vec3::ONE,
+        }),
         transform: Transform::from_xyz(0.0, 2.0, 0.0),
         ..default()
     });
@@ -97,8 +101,8 @@ mod camera_controller {
     fn camera_controller(
         time: Res<Time>,
         mut mouse_events: EventReader<MouseMotion>,
-        mouse_button_input: Res<Input<MouseButton>>,
-        key_input: Res<Input<KeyCode>>,
+        mouse_button_input: Res<ButtonInput<MouseButton>>,
+        key_input: Res<ButtonInput<KeyCode>>,
         mut query: Query<(&mut Transform, &mut CameraController), With<Camera>>,
     ) {
         let dt = time.delta_seconds();
@@ -106,22 +110,22 @@ mod camera_controller {
         if let Ok((mut transform, mut state)) = query.get_single_mut() {
             // Handle key input
             let mut axis_input = Vec3::ZERO;
-            if key_input.pressed(KeyCode::W) {
+            if key_input.pressed(KeyCode::KeyW) {
                 axis_input.z += 1.0;
             }
-            if key_input.pressed(KeyCode::S) {
+            if key_input.pressed(KeyCode::KeyS) {
                 axis_input.z -= 1.0;
             }
-            if key_input.pressed(KeyCode::D) {
+            if key_input.pressed(KeyCode::KeyD) {
                 axis_input.x += 1.0;
             }
-            if key_input.pressed(KeyCode::A) {
+            if key_input.pressed(KeyCode::KeyA) {
                 axis_input.x -= 1.0;
             }
-            if key_input.pressed(KeyCode::E) {
+            if key_input.pressed(KeyCode::KeyE) {
                 axis_input.y += 1.0;
             }
-            if key_input.pressed(KeyCode::Q) {
+            if key_input.pressed(KeyCode::KeyQ) {
                 axis_input.y -= 1.0;
             }
 
@@ -139,8 +143,8 @@ mod camera_controller {
                     state.velocity = Vec3::ZERO;
                 }
             }
-            let forward = transform.forward();
-            let right = transform.right();
+            let forward = *transform.forward();
+            let right = *transform.right();
             transform.translation += state.velocity.x * dt * right
                 + state.velocity.y * dt * Vec3::Y
                 + state.velocity.z * dt * forward;


### PR DESCRIPTION
I followed the migration guide to update this to bevy 0.13. However there is currently a WGPU error when you try to run it:
```
wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `pbr_grid_shadow_pipeline`
    Error matching ShaderStages(VERTEX) shader requirements against the pipeline
    Shader global ResourceBinding { group: 1, binding: 0 } is not available in the pipeline layout
    Storage class Uniform doesn't match the shader Storage { access: StorageAccess(LOAD) }
```
I think this is due to the swapping of material and mesh bind groups in bevy 0.13, but I don't know enough about this to feel comfortable fiddling around with the numbers. Any help with that appreciated!