### PR TITLE
Fix broken rendering in MacOS

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -25,11 +25,9 @@ fn setup_system(
         Transform::from_xyz(0.0, 4.37, 14.77),
         CameraController::default(),
     ));
-    
+
     commands.spawn((
-        DirectionalLight {
-            ..default()
-        },
+        DirectionalLight { ..default() },
         Transform::from_translation(Vec3::X * 15. + Vec3::Y * 20.).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 
@@ -38,8 +36,8 @@ fn setup_system(
         Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
         MeshMaterial3d(standard_materials.add(StandardMaterial::default())),
         Transform::from_xyz(3.0, 4.0, 0.0)
-        .with_rotation(Quat::from_rotation_arc(Vec3::Y, Vec3::ONE.normalize()))
-        .with_scale(Vec3::splat(1.5)),
+            .with_rotation(Quat::from_rotation_arc(Vec3::Y, Vec3::ONE.normalize()))
+            .with_scale(Vec3::splat(1.5)),
     ));
 
     commands.spawn((
@@ -48,6 +46,11 @@ fn setup_system(
         Transform::from_xyz(0.0, 2.0, 0.0),
     ));
 
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(standard_materials.add(StandardMaterial::default())),
+        Transform::from_xyz(0.0, -2.0, 0.0),
+    ));
 }
 
 // This is a simplified version of the camera controller used in bevy examples

--- a/src/grid.wgsl
+++ b/src/grid.wgsl
@@ -118,12 +118,13 @@ fn fragment(in: VertexOutput) -> FragmentOutput {
 
     let a_0 = alpha.x + alpha.y + alpha.z;
     alpha /= a_0;
+    // On MacOS the line above could generate NaNs and render as black instead of transparent
+    alpha = clamp(alpha, vec3(0.0), vec3(1.0));
     let axis_color = mix(grid_settings.x_axis_col, grid_settings.z_axis_col, step(grid3.x, grid3.y));
     var grid_color = vec4(
         axis_color * alpha.x + grid_settings.major_line_col.rgb * alpha.y + grid_settings.minor_line_col.rgb * alpha.z,
         max(a_0 * alpha_fadeout, 0.0),
     );
-
     out.color = grid_color;
 
     return out;


### PR DESCRIPTION
The alpha ended up with NaN values between lines and it seems like macos renders that as black while on other platforms it was transparent.

I also added a cube bellow the grid to hopefully catch a similar bug in the future.